### PR TITLE
fix unclickable elements + uncentered group chat name

### DIFF
--- a/import.css
+++ b/import.css
@@ -1380,3 +1380,19 @@ div[class*="threadSidebarOpen_"]>div>section>div[class^="upperContainer_"] {
     margin-top: 12px;
     margin-bottom: 0px !important;
 }
+
+/* CLICKABILITY ISSUES */
+
+.toolbar__9293f,
+.container__49508,
+.hoverableContainer__754bd,
+.titleWrapper__9293f,
+.iconWrapper__9293f{
+    -webkit-app-region: no-drag;
+}
+
+/* UNCENTERED GROUP TITLE */
+
+.hoverableContainer__754bd{
+    align-self: center;
+}


### PR DESCRIPTION
fixed the fact you couldn't click the following
![image](https://github.com/user-attachments/assets/c0b646b1-5332-453a-810f-1099c84b70e8)
![image](https://github.com/user-attachments/assets/b2c3d244-d861-4465-8d9e-acf1277359f1)
and the misalignment of the group chat name (compare to image above)
![image](https://github.com/user-attachments/assets/ac6276e9-c3b2-413c-9bc9-5238e328b2e9)
